### PR TITLE
"Added api keygen functionality if user supplies '-u {username}' runt…

### DIFF
--- a/pan-qb.py
+++ b/pan-qb.py
@@ -2,6 +2,9 @@
 
 import requests
 import argparse
+import getpass
+import re
+
 requests.packages.urllib3.disable_warnings()
 
 
@@ -16,18 +19,29 @@ requests.packages.urllib3.disable_warnings()
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Quick Backup of onboard firewall configuration')
-    parser.add_argument('-fw', type=str, help='IP Address of Firewall')
-    parser.add_argument('-k', '--api_key', type=str, help='API Key with access to Firewall')
+    parser.add_argument('-fw', type=str, help='IP Address of firewall')
+    parser.add_argument('-k', '--api_key', type=str, help='API Key with access to firewall(s)')
     parser.add_argument('-out', type=str, help='Output file where the configuration should be written')
     parser.add_argument('-fwlist', type=str, help='CSV file of firewalls to backup')
+    parser.add_argument('-u', type=str, help='Username with access to firewall(s)')
     args = parser.parse_args()
     return parser, args
+
+
+def api_keygen(fw, username):
+    password = getpass.getpass(prompt='Enter password for user {}: '.format(username))
+    headers = { 'type': 'keygen', 'user': username, 'password': password}
+    response = requests.get('https://{}/api'.format(fw), params=headers, verify=False)
+    key = re.findall('<key>(.*)</key>', response.text)
+    if key:
+        key = key[0]
+    return key
 
 
 def pull_backup(fw, api_key, outfile):
     config_out = open(outfile, 'w')
     backup_headers = {'type': 'export', 'key': api_key, 'category': 'configuration'}
-    backup_req = requests.get('https://%s/api' % fw, params=backup_headers, verify=False)
+    backup_req = requests.get('https://{}/api'.format(fw), params=backup_headers, verify=False)
     config_out.write(backup_req.content)
     config_out.close()
 
@@ -41,7 +55,10 @@ def pull_firewalllist(fwlist):
 
 def control():
     backup_parser, backup_args = parse_args()
-    if backup_args.fw and backup_args.api_key and backup_args.out:
+    if backup_args.fw and backup_args.u and backup_args.out:
+        key = api_keygen(backup_args.fw, backup_args.u)
+        pull_backup(backup_args.fw, key, backup_args.out)
+    elif backup_args.fw and backup_args.api_key and backup_args.out:
         pull_backup(backup_args.fw, backup_args.api_key, backup_args.out)
     elif backup_args.fwlist:
         pull_firewalllist(backup_args.fwlist)


### PR DESCRIPTION
…ime arg. Also updated to newer string formatting approach."

I'm wondering if this is the functionality you were shooting for. User should supply the -u and a username without requiring an API key. This currently doesn't work with the fwlist but it would be trivial to extend for that (just an additional elif line under control(), just was too lazy to do it right now!).